### PR TITLE
Fix validator loading via plugins package

### DIFF
--- a/tests/test_config_editor.py
+++ b/tests/test_config_editor.py
@@ -70,6 +70,10 @@ def test_plugin_validation(editor, tmp_path):
     assert calls['validate'] == 1
 
 
+def test_dynamic_loading(editor):
+    assert any(type(v).__name__ == "NginxValidator" for v in editor.validators)
+
+
 # Tests for save_or_backup
 def test_save_or_backup_success(editor, sample_config, monkeypatch):
     monkeypatch.setattr(editor, "validate_config", lambda path: True)


### PR DESCRIPTION
## Summary
- remove `ConfigValidator` from `config_editor`
- import `ConfigValidator` from the plugins package
- search for validators in the `plugins/validators` directory
- ensure `NginxValidator` loads correctly and test dynamic loading

## Testing
- `pytest -q`