### PR TITLE
Fix .gitignore formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-__pycache__/\n*.pyc\n.env
+__pycache__/
+*.pyc
+.env


### PR DESCRIPTION
## Summary
- split entries in `.gitignore` onto separate lines so that pycache files are ignored properly

## Testing
- `pytest -q`
