### PR TITLE
Import ConfigValidator from plugins

### DIFF
--- a/src/config_editor.py
+++ b/src/config_editor.py
@@ -7,15 +7,7 @@ import json
 import importlib
 from pathlib import Path
 
-
-class ConfigValidator:
-    def detect(self, filepath: str) -> bool:
-        """Erkennt, ob das Plugin für die Datei zuständig ist."""
-        return False
-
-    def validate(self, filepath: str) -> bool:
-        """Führt die Validierung durch."""
-        return False
+from plugins.__init__ import ConfigValidator
 
 
 class ConfigEditor:


### PR DESCRIPTION
## Summary
- remove `ConfigValidator` definition from `config_editor.py`
- use the shared `ConfigValidator` class from `plugins.__init__`

## Testing
- `pytest -q` *(fails: fixture 'mocker' not found)*