### PR TITLE
Fix plugin loader to load validators correctly

### DIFF
--- a/src/config_editor.py
+++ b/src/config_editor.py
@@ -5,17 +5,10 @@ import shutil
 import os
 import json
 import importlib
+import importlib.util
 from pathlib import Path
 
-
-class ConfigValidator:
-    def detect(self, filepath: str) -> bool:
-        """Erkennt, ob das Plugin für die Datei zuständig ist."""
-        return False
-
-    def validate(self, filepath: str) -> bool:
-        """Führt die Validierung durch."""
-        return False
+from plugins import ConfigValidator
 
 
 class ConfigEditor:
@@ -27,7 +20,8 @@ class ConfigEditor:
         """Lädt alle Validierungs-Plugins dynamisch."""
         validators = []
         try:
-            plugin_dir = Path(__file__).parent / "plugins/validators"
+            # Plugins liegen auf Projektebene, nicht neben diesem Modul
+            plugin_dir = Path(__file__).resolve().parent.parent / "plugins" / "validators"
             for file in plugin_dir.glob("*.py"):
                 if file.name == "__init__.py":
                     continue


### PR DESCRIPTION
## Summary
- import `ConfigValidator` from `plugins`
- search for validator plugins in the project-level `plugins/validators` directory

## Testing
- `pytest -q` *(fails: fixture 'mocker' not found)*
- `pytest tests/test_config_editor.py::test_parse_config_valid -q`
- `pytest tests/test_config_editor.py::test_validate_json -q`
