### PR TITLE
Add placeholder GUI modules

### DIFF
--- a/src/modules/config_loader.py
+++ b/src/modules/config_loader.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class ConfigLoader:
+    """Simple loader for JSON configuration files."""
+
+    def __init__(self, path: str | Path | None = None):
+        self.path = Path(path) if path else None
+
+    def load(self) -> Dict[str, Any]:
+        """Load and return configuration data.
+
+        Returns an empty dict if no path is provided or loading fails.
+        """
+        if not self.path:
+            return {}
+
+        try:
+            with open(self.path, "r") as fh:
+                return json.load(fh)
+        except FileNotFoundError:
+            raise
+        except Exception:
+            return {}

--- a/src/modules/manpage_explorer.py
+++ b/src/modules/manpage_explorer.py
@@ -1,0 +1,9 @@
+class ManpageExplorer:
+    """Placeholder GUI component for exploring configuration entries."""
+
+    def __init__(self):
+        self.data = None
+
+    def populate(self, data):
+        """Store data for later use in the GUI."""
+        self.data = data


### PR DESCRIPTION
## Summary
- add minimal placeholder modules for GUI use
- provide `ManpageExplorer` and `ConfigLoader` so imports succeed

## Testing
- `pytest -q`