### PR TITLE
Add tests for parsing errors, plugins and RBAC

### DIFF
--- a/tests/test_parsing_and_plugins.py
+++ b/tests/test_parsing_and_plugins.py
@@ -1,0 +1,75 @@
+import os
+import pytest
+
+from src.config_editor import ConfigEditor
+
+
+@pytest.fixture
+def editor_no_plugins(monkeypatch):
+    """ConfigEditor instance without any validators loaded."""
+    ed = ConfigEditor()
+    ed.validators = []
+    return ed
+
+
+def test_parse_config_invalid_lines(editor_no_plugins, tmp_path):
+    cfg = tmp_path / "test.conf"
+    cfg.write_text("""
+key1=value1
+invalid_line
+key2=value2
+    """)
+    entries = editor_no_plugins.parse_config(cfg)
+    assert ("key1", "value1") in entries
+    assert ("key2", "value2") in entries
+    # Invalid line should be ignored
+    assert len(entries) == 2
+
+
+def test_validate_invalid_json(editor_no_plugins, tmp_path):
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text('{"key": "value"')  # missing closing brace
+    assert editor_no_plugins.validate_config(str(bad_json)) is False
+
+
+def test_validate_invalid_yaml(editor_no_plugins, tmp_path):
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text("key1: value1:\n  - broken")
+    assert editor_no_plugins.validate_config(str(bad_yaml)) is False
+
+
+class DummyPlugin:
+    def __init__(self, detect_return=True, validate_return=True):
+        self.detect_called = 0
+        self.validate_called = 0
+        self._detect_return = detect_return
+        self._validate_return = validate_return
+
+    def detect(self, path):
+        self.detect_called += 1
+        return self._detect_return
+
+    def validate(self, path):
+        self.validate_called += 1
+        return self._validate_return
+
+
+def test_plugin_skip_when_not_detected(editor_no_plugins, tmp_path):
+    plugin = DummyPlugin(detect_return=False)
+    editor_no_plugins.validators = [plugin]
+    target = tmp_path / "file.txt"
+    target.write_text("data")
+    assert editor_no_plugins.validate_config(str(target)) is True
+    assert plugin.detect_called == 1
+    # validate should not be called because detect returned False
+    assert plugin.validate_called == 0
+
+
+def test_plugin_validation_failure(editor_no_plugins, tmp_path):
+    plugin = DummyPlugin(detect_return=True, validate_return=False)
+    editor_no_plugins.validators = [plugin]
+    target = tmp_path / "file.conf"
+    target.write_text("data")
+    assert editor_no_plugins.validate_config(str(target)) is False
+    assert plugin.detect_called == 1
+    assert plugin.validate_called == 1

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+import types
+
+
+def _load_rbac(monkeypatch):
+    """Import rbac module with a temporary yaml stub."""
+    stub = types.SimpleNamespace(safe_load=lambda f: {})
+    monkeypatch.setitem(sys.modules, 'yaml', stub)
+    if 'src.rbac' in sys.modules:
+        return importlib.reload(sys.modules['src.rbac'])
+    return importlib.import_module('src.rbac')
+
+
+def test_is_change_allowed_positive(monkeypatch):
+    rbac = _load_rbac(monkeypatch)
+    data = {
+        'roles': {
+            'admin': {'allowed_params': ['all']},
+            'junior': {'allowed_params': ['foo.bar']},
+        }
+    }
+    assert rbac.is_change_allowed('admin', 'anything', data)
+    assert rbac.is_change_allowed('junior', 'foo.bar', data)
+
+
+def test_is_change_allowed_negative(monkeypatch):
+    rbac = _load_rbac(monkeypatch)
+    data = {
+        'roles': {
+            'junior': {'allowed_params': ['foo.bar']}
+        }
+    }
+    assert not rbac.is_change_allowed('junior', 'other.param', data)
+    assert not rbac.is_change_allowed('unknown', 'foo.bar', data)
+


### PR DESCRIPTION
## Summary
- expand ConfigEditor tests to cover invalid JSON/YAML, bad lines, and plugin behaviour
- add RBAC tests for `is_change_allowed`

## Testing
- `pytest -q`